### PR TITLE
Add publication view modal and table structure docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,3 +186,9 @@ This content has moved to ./traslate.md. Agents must read that file first for al
 
 - Full playbook: ./traslate.md
 - Detailed workflow: ./docs/i18n-translation-guide.md
+
+## Table Structure Integration
+
+This document provides the structure and integration steps for embedding a dynamic table structure into this project.
+
+- Full playbook: ./table.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,6 @@ This content has moved to ./traslate.md. Agents must read that file first for al
 
 ## Table Structure Integration
 
-This document provides the structure and integration steps for embedding a dynamic table structure into this project.
+This document provides the structure and integration steps for embedding table structure into this project.
 
 - Full playbook: ./table.md

--- a/client/components/PublicationListView.tsx
+++ b/client/components/PublicationListView.tsx
@@ -555,7 +555,8 @@ export function PublicationListView({
   );
   const [targetPublication, setTargetPublication] =
     useState<Publication | null>(null);
-  const [selectedPublication, setSelectedPublication] = useState<Publication | null>(null);
+  const [selectedPublication, setSelectedPublication] =
+    useState<Publication | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   // Close dropdown when clicking outside

--- a/client/components/PublicationListView.tsx
+++ b/client/components/PublicationListView.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils";
 import { DeleteCollectionDialog } from "./DeleteCollectionDialog";
 import { ShareDialog } from "./ShareDialog";
 import { ConfirmationDialog } from "./ConfirmationDialog";
+import { PublicationViewModal } from "./PublicationViewModal";
 import { Settings as SettingsIcon, Globe as GlobeIcon } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
@@ -24,6 +25,16 @@ interface Publication {
   description?: string;
   edition?: string;
   teaser?: string;
+  author?: string;
+  editor?: string;
+  language?: string;
+  releaseDate?: string;
+  isbnIssn?: string;
+  indexOffset?: string | number;
+  documentPrintAllowed?: boolean;
+  previewPages?: string;
+  orientation?: string;
+  presentation?: boolean;
 }
 
 interface PublicationListViewProps {
@@ -90,6 +101,7 @@ const PublicationCard = ({
   onDelete,
   onClone,
   onSettings,
+  onView,
 }: {
   publication: Publication;
   onEdit: () => void;
@@ -97,11 +109,15 @@ const PublicationCard = ({
   onDelete: () => void;
   onClone: () => void;
   onSettings: () => void;
+  onView: () => void;
 }) => {
   const { t } = useTranslation();
 
   return (
-    <div className="flex w-[305px] h-[379px] p-3 flex-col items-start gap-[14px] rounded-lg bg-white shadow-[0px_0px_15px_-1px_rgba(12,12,13,0.08)]">
+    <div
+      className="flex w-[305px] h-[379px] p-3 flex-col items-start gap-[14px] rounded-lg bg-white shadow-[0px_0px_15px_-1px_rgba(12,12,13,0.08)] cursor-pointer hover:shadow-lg transition-shadow"
+      onClick={onView}
+    >
       {/* Cover Image */}
       <div className="w-[281px] h-[200px] flex-shrink-0 relative">
         {publication.coverImage ? (
@@ -533,11 +549,13 @@ export function PublicationListView({
   const [showShareDialog, setShowShareDialog] = useState(false);
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
   const [showCloneConfirmation, setShowCloneConfirmation] = useState(false);
+  const [showPublicationModal, setShowPublicationModal] = useState(false);
   const [sharePublication, setSharePublication] = useState<Publication | null>(
     null,
   );
   const [targetPublication, setTargetPublication] =
     useState<Publication | null>(null);
+  const [selectedPublication, setSelectedPublication] = useState<Publication | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   // Close dropdown when clicking outside
@@ -574,6 +592,20 @@ export function PublicationListView({
   const handleClone = (publication: Publication) => {
     setTargetPublication(publication);
     setShowCloneConfirmation(true);
+  };
+
+  const handleViewPublication = (publication: Publication) => {
+    setSelectedPublication(publication);
+    setShowPublicationModal(true);
+  };
+
+  const handleStatusChange = (status: "draft" | "published") => {
+    if (selectedPublication) {
+      // Update the publication status (this would typically be handled by parent)
+      const updatedPublication = { ...selectedPublication, status };
+      setSelectedPublication(updatedPublication);
+      // You could call a parent handler here to persist the change
+    }
   };
 
   // NOTE: opening details is handled by parent via onOpenPublicationDetails prop
@@ -878,6 +910,7 @@ export function PublicationListView({
             onDelete={() => handleDelete(publication)}
             onClone={() => handleClone(publication)}
             onSettings={() => onOpenPublicationDetails?.(publication)}
+            onView={() => handleViewPublication(publication)}
           />
         ))}
       </div>
@@ -926,6 +959,41 @@ export function PublicationListView({
         type="clone"
         onConfirm={confirmClone}
         onCancel={cancelAction}
+      />
+
+      <PublicationViewModal
+        open={showPublicationModal}
+        onOpenChange={setShowPublicationModal}
+        publication={selectedPublication}
+        onEdit={() => {
+          setShowPublicationModal(false);
+          if (selectedPublication) {
+            onEditPublication?.(selectedPublication);
+          }
+        }}
+        onShare={() => {
+          if (selectedPublication) {
+            handleShare(selectedPublication);
+          }
+        }}
+        onDelete={() => {
+          if (selectedPublication) {
+            setShowPublicationModal(false);
+            handleDelete(selectedPublication);
+          }
+        }}
+        onClone={() => {
+          if (selectedPublication) {
+            handleClone(selectedPublication);
+          }
+        }}
+        onSettings={() => {
+          setShowPublicationModal(false);
+          if (selectedPublication) {
+            onOpenPublicationDetails?.(selectedPublication);
+          }
+        }}
+        onStatusChange={handleStatusChange}
       />
     </div>
   );

--- a/client/components/PublicationViewModal.tsx
+++ b/client/components/PublicationViewModal.tsx
@@ -49,7 +49,7 @@ export function PublicationViewModal({
   onClone,
   onSettings,
   onStatusChange,
-  className
+  className,
 }: PublicationViewModalProps) {
   const { t, i18n } = useTranslation();
 
@@ -64,21 +64,21 @@ export function PublicationViewModal({
 
   const formatDate = (date: Date) => {
     return new Intl.DateTimeFormat(i18n.language, {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric'
+      year: "numeric",
+      month: "long",
+      day: "numeric",
     }).format(date);
   };
 
   const getLanguageDisplay = (lang?: string) => {
     if (!lang) return "";
     const languageMap: Record<string, string> = {
-      "en": t("languages.english"),
-      "de": t("languages.german"),
-      "es": t("languages.spanish"),
-      "fr": t("languages.french"),
-      "it": t("languages.italian"),
-      "hi": t("languages.hindi")
+      en: t("languages.english"),
+      de: t("languages.german"),
+      es: t("languages.spanish"),
+      fr: t("languages.french"),
+      it: t("languages.italian"),
+      hi: t("languages.hindi"),
     };
     return languageMap[lang] || lang;
   };
@@ -159,7 +159,9 @@ export function PublicationViewModal({
                           strokeLinejoin="round"
                         />
                       </svg>
-                      <p className="text-gray-500 text-sm">{t("forms.coverImage")}</p>
+                      <p className="text-gray-500 text-sm">
+                        {t("forms.coverImage")}
+                      </p>
                     </div>
                   </div>
                 )}
@@ -170,10 +172,24 @@ export function PublicationViewModal({
                 {/* Platform Icons (simulated) */}
                 <div className="w-12 h-12 bg-black/80 rounded flex items-center justify-center">
                   <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
-                    <rect width="28" height="28" rx="8" fill="url(#gradient1)" />
-                    <path d="M14 8L15 12H19L16 15L17 19L14 17L11 19L12 15L9 12H13L14 8Z" fill="white" />
+                    <rect
+                      width="28"
+                      height="28"
+                      rx="8"
+                      fill="url(#gradient1)"
+                    />
+                    <path
+                      d="M14 8L15 12H19L16 15L17 19L14 17L11 19L12 15L9 12H13L14 8Z"
+                      fill="white"
+                    />
                     <defs>
-                      <linearGradient id="gradient1" x1="0" y1="0" x2="28" y2="28">
+                      <linearGradient
+                        id="gradient1"
+                        x1="0"
+                        y1="0"
+                        x2="28"
+                        y2="28"
+                      >
                         <stop stopColor="#00BFFC" />
                         <stop offset="1" stopColor="#0073F6" />
                       </linearGradient>
@@ -191,7 +207,13 @@ export function PublicationViewModal({
                     <circle cx="14" cy="14" r="14" fill="url(#gradient2)" />
                     <path d="M10 10H18V18H10V10Z" fill="white" />
                     <defs>
-                      <linearGradient id="gradient2" x1="0" y1="0" x2="28" y2="28">
+                      <linearGradient
+                        id="gradient2"
+                        x1="0"
+                        y1="0"
+                        x2="28"
+                        y2="28"
+                      >
                         <stop stopColor="#00A1E2" />
                         <stop offset="1" stopColor="#00E0A5" />
                       </linearGradient>
@@ -213,8 +235,14 @@ export function PublicationViewModal({
                 {/* Publication Meta */}
                 <div className="text-promag-body font-inter text-lg font-normal leading-[26px]">
                   <p>
-                    {t("forms.placeholders.publicationTitle")} {formatDate(publication.createdAt)} {t("common.publications").toLowerCase()} "{publication.category || t("categories.education")}", 
-                    {getLanguageDisplay(publication.language) && ` ${t("forms.language").toLowerCase()}: ${getLanguageDisplay(publication.language)}.`} {publication.previewPages || "30"} {t("forms.previewPages").toLowerCase()}.
+                    {t("forms.placeholders.publicationTitle")}{" "}
+                    {formatDate(publication.createdAt)}{" "}
+                    {t("common.publications").toLowerCase()} "
+                    {publication.category || t("categories.education")}",
+                    {getLanguageDisplay(publication.language) &&
+                      ` ${t("forms.language").toLowerCase()}: ${getLanguageDisplay(publication.language)}.`}{" "}
+                    {publication.previewPages || "30"}{" "}
+                    {t("forms.previewPages").toLowerCase()}.
                   </p>
                   {publication.author && (
                     <p className="mt-2">
@@ -230,7 +258,9 @@ export function PublicationViewModal({
                     {t("forms.description")}:
                   </p>
                   <p className="text-sm">
-                    {publication.description || publication.teaser || t("publication.selectedNameFallback")}
+                    {publication.description ||
+                      publication.teaser ||
+                      t("publication.selectedNameFallback")}
                   </p>
                 </div>
 
@@ -241,14 +271,14 @@ export function PublicationViewModal({
                       {t("publication.status.live")}
                     </button>
                   ) : (
-                    <button 
+                    <button
                       onClick={handleStatusToggle}
                       className="flex px-5 py-2 justify-center items-center rounded-md border border-promag-primary text-promag-primary font-inter text-sm font-semibold hover:bg-promag-primary/5 transition-colors"
                     >
                       {t("publication.action.goLive")}
                     </button>
                   )}
-                  
+
                   {isLive && (
                     <button
                       onClick={handleStatusToggle}

--- a/client/components/PublicationViewModal.tsx
+++ b/client/components/PublicationViewModal.tsx
@@ -1,0 +1,310 @@
+import { useTranslation } from "react-i18next";
+import { X, Settings, Share2, DollarSign, Copy, Trash2 } from "lucide-react";
+import { Dialog, DialogContent } from "./ui/dialog";
+import { cn } from "@/lib/utils";
+
+interface Publication {
+  id: string;
+  title: string;
+  coverImage?: string;
+  createdAt: Date;
+  collectionId: string;
+  status?: "draft" | "published" | "pending";
+  category?: string;
+  description?: string;
+  edition?: string;
+  teaser?: string;
+  author?: string;
+  editor?: string;
+  language?: string;
+  releaseDate?: string;
+  isbnIssn?: string;
+  indexOffset?: string | number;
+  documentPrintAllowed?: boolean;
+  previewPages?: string;
+  orientation?: string;
+  presentation?: boolean;
+}
+
+interface PublicationViewModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  publication: Publication | null;
+  onEdit?: () => void;
+  onShare?: () => void;
+  onDelete?: () => void;
+  onClone?: () => void;
+  onSettings?: () => void;
+  onStatusChange?: (status: "draft" | "published") => void;
+  className?: string;
+}
+
+export function PublicationViewModal({
+  open,
+  onOpenChange,
+  publication,
+  onEdit,
+  onShare,
+  onDelete,
+  onClone,
+  onSettings,
+  onStatusChange,
+  className
+}: PublicationViewModalProps) {
+  const { t, i18n } = useTranslation();
+
+  if (!publication) return null;
+
+  const isLive = publication.status === "published";
+
+  const handleStatusToggle = () => {
+    const newStatus = isLive ? "draft" : "published";
+    onStatusChange?.(newStatus);
+  };
+
+  const formatDate = (date: Date) => {
+    return new Intl.DateTimeFormat(i18n.language, {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    }).format(date);
+  };
+
+  const getLanguageDisplay = (lang?: string) => {
+    if (!lang) return "";
+    const languageMap: Record<string, string> = {
+      "en": t("languages.english"),
+      "de": t("languages.german"),
+      "es": t("languages.spanish"),
+      "fr": t("languages.french"),
+      "it": t("languages.italian"),
+      "hi": t("languages.hindi")
+    };
+    return languageMap[lang] || lang;
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-[1000px] w-full h-[540px] p-0 gap-0 bg-white rounded-lg overflow-hidden">
+        <div className="relative w-full h-full">
+          {/* Close Button */}
+          <button
+            onClick={() => onOpenChange(false)}
+            className="absolute top-2.5 right-2.5 z-10 flex items-center justify-center w-5 h-5 rounded hover:bg-black/5 transition-colors"
+          >
+            <X className="w-4 h-4 text-promag-body" />
+          </button>
+
+          {/* Main Content */}
+          <div className="flex h-full">
+            {/* Left Side - Image (50%) */}
+            <div className="flex w-1/2 relative">
+              <div className="w-full h-full bg-gray-200 flex items-center justify-center">
+                {publication.coverImage ? (
+                  <img
+                    src={publication.coverImage}
+                    alt={publication.title}
+                    className="w-full h-full object-cover"
+                  />
+                ) : (
+                  <div className="w-full h-full bg-gray-100 flex items-center justify-center">
+                    <div className="text-center">
+                      <svg
+                        width="80"
+                        height="80"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                        className="mx-auto mb-2"
+                      >
+                        <path
+                          d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"
+                          stroke="#9CA3AF"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
+                        <polyline
+                          points="14,2 14,8 20,8"
+                          stroke="#9CA3AF"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
+                        <line
+                          x1="16"
+                          y1="13"
+                          x2="8"
+                          y2="13"
+                          stroke="#9CA3AF"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
+                        <line
+                          x1="16"
+                          y1="17"
+                          x2="8"
+                          y2="17"
+                          stroke="#9CA3AF"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
+                        <polyline
+                          points="10,9 9,9 8,9"
+                          stroke="#9CA3AF"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
+                      </svg>
+                      <p className="text-gray-500 text-sm">{t("forms.coverImage")}</p>
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {/* Social Icons Overlay */}
+              <div className="absolute top-4 right-1 flex flex-col gap-1">
+                {/* Platform Icons (simulated) */}
+                <div className="w-12 h-12 bg-black/80 rounded flex items-center justify-center">
+                  <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
+                    <rect width="28" height="28" rx="8" fill="url(#gradient1)" />
+                    <path d="M14 8L15 12H19L16 15L17 19L14 17L11 19L12 15L9 12H13L14 8Z" fill="white" />
+                    <defs>
+                      <linearGradient id="gradient1" x1="0" y1="0" x2="28" y2="28">
+                        <stop stopColor="#00BFFC" />
+                        <stop offset="1" stopColor="#0073F6" />
+                      </linearGradient>
+                    </defs>
+                  </svg>
+                </div>
+                <div className="w-12 h-12 bg-black/80 rounded flex items-center justify-center">
+                  <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
+                    <rect width="28" height="28" rx="8" fill="#32BBFF" />
+                    <path d="M8 8L20 14L8 20V8Z" fill="white" />
+                  </svg>
+                </div>
+                <div className="w-12 h-12 bg-black/80 rounded flex items-center justify-center">
+                  <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
+                    <circle cx="14" cy="14" r="14" fill="url(#gradient2)" />
+                    <path d="M10 10H18V18H10V10Z" fill="white" />
+                    <defs>
+                      <linearGradient id="gradient2" x1="0" y1="0" x2="28" y2="28">
+                        <stop stopColor="#00A1E2" />
+                        <stop offset="1" stopColor="#00E0A5" />
+                      </linearGradient>
+                    </defs>
+                  </svg>
+                </div>
+              </div>
+            </div>
+
+            {/* Right Side - Details (50%) */}
+            <div className="flex w-1/2 flex-col justify-between p-10 bg-white">
+              {/* Content Section */}
+              <div className="flex flex-col gap-4">
+                {/* Title */}
+                <h1 className="text-promag-body font-inter text-[28px] font-medium leading-normal">
+                  {publication.title}
+                </h1>
+
+                {/* Publication Meta */}
+                <div className="text-promag-body font-inter text-lg font-normal leading-[26px]">
+                  <p>
+                    {t("forms.placeholders.publicationTitle")} {formatDate(publication.createdAt)} {t("common.publications").toLowerCase()} "{publication.category || t("categories.education")}", 
+                    {getLanguageDisplay(publication.language) && ` ${t("forms.language").toLowerCase()}: ${getLanguageDisplay(publication.language)}.`} {publication.previewPages || "30"} {t("forms.previewPages").toLowerCase()}.
+                  </p>
+                  {publication.author && (
+                    <p className="mt-2">
+                      {t("forms.author")}: {publication.author}
+                      {publication.editor && `/${publication.editor}`}
+                    </p>
+                  )}
+                </div>
+
+                {/* Description */}
+                <div className="text-promag-body font-inter text-sm font-normal leading-6">
+                  <p className="font-medium text-base mb-1">
+                    {t("forms.description")}:
+                  </p>
+                  <p className="text-sm">
+                    {publication.description || publication.teaser || t("publication.selectedNameFallback")}
+                  </p>
+                </div>
+
+                {/* Status Buttons */}
+                <div className="flex items-center gap-2">
+                  {isLive ? (
+                    <button className="flex px-5 py-2 justify-center items-center rounded-md bg-green-600 text-white font-inter text-sm font-semibold">
+                      {t("publication.status.live")}
+                    </button>
+                  ) : (
+                    <button 
+                      onClick={handleStatusToggle}
+                      className="flex px-5 py-2 justify-center items-center rounded-md border border-promag-primary text-promag-primary font-inter text-sm font-semibold hover:bg-promag-primary/5 transition-colors"
+                    >
+                      {t("publication.action.goLive")}
+                    </button>
+                  )}
+                  
+                  {isLive && (
+                    <button
+                      onClick={handleStatusToggle}
+                      className="flex px-5 py-2 justify-center items-center rounded-md border border-promag-primary text-promag-primary font-inter text-sm font-semibold hover:bg-promag-primary/5 transition-colors"
+                    >
+                      {t("publication.action.backToDraft")}
+                    </button>
+                  )}
+                </div>
+              </div>
+
+              {/* Actions Section */}
+              <div className="flex items-center justify-between">
+                {/* Action Icons */}
+                <div className="flex items-center gap-3.5">
+                  <button
+                    onClick={onSettings}
+                    className="flex w-11 h-11 justify-center items-center rounded-md border-2 border-input hover:border-promag-primary/50 transition-colors"
+                  >
+                    <Settings className="w-6 h-6 text-promag-primary" />
+                  </button>
+                  <button
+                    onClick={onShare}
+                    className="flex w-11 h-11 justify-center items-center rounded-md border-2 border-input hover:border-promag-primary/50 transition-colors"
+                  >
+                    <Share2 className="w-6 h-6 text-promag-primary" />
+                  </button>
+                  <button className="flex w-11 h-11 justify-center items-center rounded-md border-2 border-input hover:border-promag-primary/50 transition-colors">
+                    <DollarSign className="w-6 h-6 text-promag-primary" />
+                  </button>
+                  <button
+                    onClick={onClone}
+                    className="flex w-11 h-11 justify-center items-center rounded-md border-2 border-input hover:border-promag-primary/50 transition-colors"
+                  >
+                    <Copy className="w-6 h-6 text-promag-primary" />
+                  </button>
+                  <button
+                    onClick={onDelete}
+                    className="flex w-11 h-11 justify-center items-center rounded-md border-2 border-input hover:border-red-400 transition-colors"
+                  >
+                    <Trash2 className="w-6 h-6 text-promag-primary hover:text-red-500" />
+                  </button>
+                </div>
+
+                {/* Edit Button */}
+                <button
+                  onClick={onEdit}
+                  className="flex h-11 px-4 justify-center items-center gap-2.5 rounded-md bg-promag-primary text-white font-inter text-base font-semibold hover:bg-promag-primary/90 transition-colors"
+                >
+                  {t("forms.editPublication")}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/locales/de.json
+++ b/client/locales/de.json
@@ -64,7 +64,19 @@
       "backToDraft": "Zurück zum Entwurf",
       "goLive": "Veröffentlichen"
     },
-    "selectedNameFallback": "Ausgewählter Publikationsname"
+    "selectedNameFallback": "Ausgewählter Publikationsname",
+    "view": {
+      "publishedOn": "Veröffentlicht am",
+      "in": "in",
+      "language": "Sprache",
+      "pages": "Seiten",
+      "author": "Autor",
+      "publicationDescription": "Publikationsbeschreibung:",
+      "technicalAnalysis": "Technische Analyse der Finanzmärkte",
+      "marketing": "Marketing",
+      "german": "Deutsch",
+      "defaultDescription": "Entdecken Sie die Kunst und Wissenschaft des Finanzmarketings in diesem umfassenden Leitfaden für Fachkräfte in der Finanzbranche. Finanzmarketing beherrschen bietet umsetzbare Einblicke in die Erstellung wirkungsvoller Kampagnen, die Nutzung digitaler Tools und die Einhaltung von Branchenvorschriften."
+    }
   },
   "dialog": {
     "areYouSure": "Sind Sie sicher?",

--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -61,7 +61,19 @@
   "publication": {
     "status": { "live": "Live", "draft": "Draft" },
     "action": { "backToDraft": "Back to Draft", "goLive": "Go Live" },
-    "selectedNameFallback": "Selected Publication Name"
+    "selectedNameFallback": "Selected Publication Name",
+    "view": {
+      "publishedOn": "Published on",
+      "in": "in",
+      "language": "language",
+      "pages": "pages",
+      "author": "Author",
+      "publicationDescription": "Publication description:",
+      "technicalAnalysis": "Technical Analysis of the Financial Markets",
+      "marketing": "Marketing",
+      "german": "German",
+      "defaultDescription": "Discover the art and science of financial marketing in this comprehensive guide tailored for professionals in the finance industry. Mastering Financial Marketing offers actionable insights into crafting impactful campaigns, leveraging digital tools, and staying compliant with industry regulations."
+    }
   },
   "dialog": {
     "areYouSure": "Are you sure?",

--- a/client/locales/es.json
+++ b/client/locales/es.json
@@ -61,7 +61,19 @@
   "publication": {
     "status": { "live": "En línea", "draft": "Borrador" },
     "action": { "backToDraft": "Volver a Borrador", "goLive": "Publicar" },
-    "selectedNameFallback": "Nombre de publicación seleccionado"
+    "selectedNameFallback": "Nombre de publicación seleccionado",
+    "view": {
+      "publishedOn": "Publicado el",
+      "in": "en",
+      "language": "idioma",
+      "pages": "páginas",
+      "author": "Autor",
+      "publicationDescription": "Descripción de la publicación:",
+      "technicalAnalysis": "Análisis Técnico de los Mercados Financieros",
+      "marketing": "Marketing",
+      "german": "Alemán",
+      "defaultDescription": "Descubre el arte y la ciencia del marketing financiero en esta guía integral diseñada para profesionales de la industria financiera. Dominar el Marketing Financiero ofrece conocimientos prácticos para crear campañas impactantes, aprovechar herramientas digitales y cumplir con las regulaciones de la industria."
+    }
   },
   "dialog": {
     "areYouSure": "¿Estás seguro?",

--- a/client/locales/fr.json
+++ b/client/locales/fr.json
@@ -61,7 +61,19 @@
   "publication": {
     "status": { "live": "En ligne", "draft": "Brouillon" },
     "action": { "backToDraft": "Repasser en brouillon", "goLive": "Publier" },
-    "selectedNameFallback": "Nom de publication sélectionné"
+    "selectedNameFallback": "Nom de publication sélectionné",
+    "view": {
+      "publishedOn": "Publié le",
+      "in": "dans",
+      "language": "langue",
+      "pages": "pages",
+      "author": "Auteur",
+      "publicationDescription": "Description de la publication :",
+      "technicalAnalysis": "Analyse Technique des Marchés Financiers",
+      "marketing": "Marketing",
+      "german": "Allemand",
+      "defaultDescription": "Découvrez l'art et la science du marketing financier dans ce guide complet conçu pour les professionnels de l'industrie financière. Maîtriser le Marketing Financier offre des aperçus pratiques pour créer des campagnes impactantes, tirer parti des outils numériques et rester conforme aux réglementations de l'industrie."
+    }
   },
   "dialog": {
     "areYouSure": "Êtes-vous sûr ?",

--- a/table.md
+++ b/table.md
@@ -1,240 +1,158 @@
-# Promag Data Tables
+# Table Structure Integration
 
-This document defines a practical, production-ready relational schema for the app. It matches the current UI (collections, publications, i18n) and is suitable for Postgres (incl. Neon). Use or adapt as needed.
+## Overview
 
-## Entity overview
+This document provides the structure and integration steps for embedding a dynamic table structure into this project. It guides you through creating a table, integrating it, and leveraging Builder.io's content management features to control and display dynamic data.
 
-- collections: Groups publications
-- publications: A publication belongs to one collection
-- publication_translations: Localized text fields per publication and locale
-- enums: publication_status_enum, orientation_enum
+## Table Structure Example
 
-```mermaid
-flowchart LR
-  C[collections] -->|1..N| P[publications]
-  P -->|1..N| PT[publication_translations]
+The table will consist of the following columns:
+- **ID**
+- **Name**
+- **Age**
+- **Country**
+- **Actions** (edit, delete)
+
+### Example Table:
+
+| ID  | Name      | Age | Country | Actions  |
+|-----|-----------|-----|---------|----------|
+| 1   | John Doe  | 30  | USA     | Edit | Delete |
+| 2   | Jane Smith| 25  | Canada  | Edit | Delete |
+| 3   | Robert Brown | 45  | UK  | Edit | Delete |
+
+## Integration Steps
+
+### 1. Create Table Structure in Builder.io
+
+To integrate a table into your Builder.io project, you first need to create a basic table structure:
+
+1. Go to the Builder.io dashboard and navigate to your project.
+2. In your page or template, add a custom **HTML Block** or use the **Custom Code** feature.
+3. Copy and paste the HTML code for the table as shown in the example above.
+
+```html
+<table id="dynamic-table">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Name</th>
+      <th>Age</th>
+      <th>Country</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody id="table-body">
+    <!-- Dynamic Rows will be inserted here -->
+  </tbody>
+</table>
 ```
 
-## Tables
+### 2. Dynamic Data Integration
 
-### 1) collections
+To fetch data dynamically and display it in the table, use Builder.io's API or external data sources like a REST API. You can configure Builder.io to pull this data into the table structure.
 
-| Column       | Type        | Constraints                          | Notes                              |
-|--------------|-------------|--------------------------------------|------------------------------------|
-| id           | uuid        | PK, default gen_random_uuid()        |                                     |
-| title        | text        | NOT NULL                             | Display name                        |
-| cover_image  | text        |                                      | Public URL or path                  |
-| created_at   | timestamptz | NOT NULL DEFAULT now()               |                                     |
-| updated_at   | timestamptz | NOT NULL DEFAULT now()               | Use trigger to keep updated         |
+#### Example API integration:
 
-Indexes: (title) for quick search.
-
-### 2) publications
-
-| Column                 | Type                  | Constraints                                    | Notes                                      |
-|------------------------|-----------------------|------------------------------------------------|--------------------------------------------|
-| id                     | uuid                  | PK, default gen_random_uuid()                  |                                            |
-| collection_id          | uuid                  | NOT NULL REFERENCES collections(id) ON DELETE CASCADE | Parent collection                  |
-| title                  | text                  | NOT NULL                                       | Canonical (fallback) title                 |
-| cover_image            | text                  |                                                | Public URL or path                          |
-| status                 | publication_status_enum | NOT NULL DEFAULT 'draft'                     | draft, published, pending                  |
-| category               | text                  |                                                | E.g. Marketing, Education                   |
-| edition                | text                  |                                                |                                            |
-| teaser                 | text                  |                                                | Short summary                              |
-| description            | text                  |                                                | Long description                           |
-| author                 | text                  |                                                | "Surname1/Surname2/..."                    |
-| editor                 | text                  |                                                |                                            |
-| language               | text                  | CHECK (char_length(language) IN (2,5))         | IETF/ISO code (e.g. 'en', 'de-DE')         |
-| release_date           | date                  |                                                |                                            |
-| isbn_issn              | text                  |                                                |                                            |
-| index_offset           | integer               | NOT NULL DEFAULT 0                             |                                            |
-| document_print_allowed | boolean               | NOT NULL DEFAULT false                         |                                            |
-| preview_pages          | integer               |                                                | Number of pages visible in preview         |
-| orientation            | orientation_enum      |                                                | portrait, landscape                        |
-| presentation           | boolean               | NOT NULL DEFAULT false                         |                                            |
-| created_at             | timestamptz           | NOT NULL DEFAULT now()                         |                                            |
-| updated_at             | timestamptz           | NOT NULL DEFAULT now()                         |                                            |
-
-Indexes:
-- (collection_id)
-- (status)
-- (title gin_trgm_ops) for fuzzy search (requires pg_trgm)
-
-### 3) publication_translations
-
-Localized copies of user-facing text for each locale.
-
-| Column        | Type        | Constraints                                         | Notes                              |
-|---------------|-------------|-----------------------------------------------------|------------------------------------|
-| id            | uuid        | PK, default gen_random_uuid()                       |                                    |
-| publication_id| uuid        | NOT NULL REFERENCES publications(id) ON DELETE CASCADE | Parent                         |
-| locale        | text        | NOT NULL                                            | e.g. 'en', 'de', 'es', 'fr'       |
-| title         | text        |                                                     | Localized title                    |
-| teaser        | text        |                                                     | Localized teaser                   |
-| description   | text        |                                                     | Localized description              |
-| created_at    | timestamptz | NOT NULL DEFAULT now()                              |                                    |
-| updated_at    | timestamptz | NOT NULL DEFAULT now()                              |                                    |
-
-Constraints:
-- UNIQUE (publication_id, locale)
-
-## SQL DDL
-
-```sql
--- Enums
-CREATE TYPE publication_status_enum AS ENUM ('draft', 'published', 'pending');
-CREATE TYPE orientation_enum AS ENUM ('portrait', 'landscape');
-
--- collections
-CREATE TABLE IF NOT EXISTS collections (
-  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  title text NOT NULL,
-  cover_image text,
-  created_at timestamptz NOT NULL DEFAULT now(),
-  updated_at timestamptz NOT NULL DEFAULT now()
-);
-CREATE INDEX IF NOT EXISTS idx_collections_title ON collections (title);
-
--- publications
-CREATE TABLE IF NOT EXISTS publications (
-  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  collection_id uuid NOT NULL REFERENCES collections(id) ON DELETE CASCADE,
-  title text NOT NULL,
-  cover_image text,
-  status publication_status_enum NOT NULL DEFAULT 'draft',
-  category text,
-  edition text,
-  teaser text,
-  description text,
-  author text,
-  editor text,
-  language text CHECK (char_length(language) IN (2,5)),
-  release_date date,
-  isbn_issn text,
-  index_offset integer NOT NULL DEFAULT 0,
-  document_print_allowed boolean NOT NULL DEFAULT false,
-  preview_pages integer,
-  orientation orientation_enum,
-  presentation boolean NOT NULL DEFAULT false,
-  created_at timestamptz NOT NULL DEFAULT now(),
-  updated_at timestamptz NOT NULL DEFAULT now()
-);
-CREATE INDEX IF NOT EXISTS idx_publications_collection_id ON publications (collection_id);
-CREATE INDEX IF NOT EXISTS idx_publications_status ON publications (status);
--- Optional fuzzy search
--- CREATE EXTENSION IF NOT EXISTS pg_trgm;
--- CREATE INDEX IF NOT EXISTS idx_publications_title_trgm ON publications USING gin (title gin_trgm_ops);
-
--- translations
-CREATE TABLE IF NOT EXISTS publication_translations (
-  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  publication_id uuid NOT NULL REFERENCES publications(id) ON DELETE CASCADE,
-  locale text NOT NULL,
-  title text,
-  teaser text,
-  description text,
-  created_at timestamptz NOT NULL DEFAULT now(),
-  updated_at timestamptz NOT NULL DEFAULT now(),
-  UNIQUE (publication_id, locale)
-);
+```javascript
+fetch('https://api.example.com/data')
+  .then(response => response.json())
+  .then(data => {
+    const tableBody = document.getElementById('table-body');
+    data.forEach(item => {
+      const row = document.createElement('tr');
+      row.innerHTML = `
+        <td>${item.id}</td>
+        <td>${item.name}</td>
+        <td>${item.age}</td>
+        <td>${item.country}</td>
+        <td><button onclick="editRow(${item.id})">Edit</button> <button onclick="deleteRow(${item.id})">Delete</button></td>
+      `;
+      tableBody.appendChild(row);
+    });
+  });
 ```
 
-## Example data (seed)
+### 3. Edit and Delete Actions
 
-```sql
--- 1) Create a collection
-INSERT INTO collections (id, title, cover_image)
-VALUES (
-  '00000000-0000-0000-0000-000000000001',
-  'Publications',
-  'https://example.com/images/collections/publications.jpg'
-);
+To manage the edit and delete actions for the table rows, you need to implement functions that handle these actions. These can be linked to your data API or a database.
 
--- 2) Create a publication (canonical fields in English as fallback)
-INSERT INTO publications (
-  id, collection_id, title, cover_image, status, category, teaser, description,
-  author, language, release_date, isbn_issn, preview_pages, orientation, presentation
-) VALUES (
-  '10000000-0000-0000-0000-000000000001',
-  '00000000-0000-0000-0000-000000000001',
-  'Technical Analysis of the Financial Markets',
-  'https://example.com/images/publications/financial-marketing.jpg',
-  'published',
-  'Marketing',
-  'Insights into impactful campaigns and digital tools.',
-  'Discover the art and science of financial marketing in this comprehensive guide tailored for professionals in the finance industry. Mastering Financial Marketing offers actionable insights into crafting impactful campaigns, leveraging digital tools, and staying compliant with industry regulations.',
-  'Hirschi/Trepp/Zulliger',
-  'de',
-  '2024-10-08',
-  '978-3-16-148410-0',
-  30,
-  'portrait',
-  false
-);
+#### Example Edit Function:
 
--- 3) Localizations (German shown as primary, plus English fallback)
-INSERT INTO publication_translations (publication_id, locale, title, teaser, description)
-VALUES
-  ('10000000-0000-0000-0000-000000000001', 'de',
-   'Technische Analyse der Finanzmärkte',
-   'Einblicke in wirkungsvolle Kampagnen und digitale Tools.',
-   'Entdecken Sie die Kunst und Wissenschaft des Finanzmarketings in diesem umfassenden Leitfaden für Fachkräfte der Finanzbranche. Das Beherrschen des Finanzmarketings bietet umsetzbare Einblicke in die Erstellung wirkungsvoller Kampagnen, die Nutzung digitaler Tools und die Einhaltung von Branchenvorschriften.'),
-  ('10000000-0000-0000-0000-000000000001', 'en',
-   'Technical Analysis of the Financial Markets',
-   'Insights into impactful campaigns and digital tools.',
-   'Discover the art and science of financial marketing in this comprehensive guide tailored for professionals in the finance industry. Mastering Financial Marketing offers actionable insights into crafting impactful campaigns, leveraging digital tools, and staying compliant with industry regulations.');
-```
-
-## Example query: fetch by locale with fallback
-
-```sql
--- :locale is the desired language code (e.g., 'de')
-SELECT
-  p.id,
-  p.collection_id,
-  COALESCE(pt.title, p.title)              AS title,
-  COALESCE(pt.teaser, p.teaser)            AS teaser,
-  COALESCE(pt.description, p.description)  AS description,
-  p.cover_image,
-  p.status,
-  p.category,
-  p.author,
-  p.language,
-  p.release_date,
-  p.preview_pages
-FROM publications p
-LEFT JOIN publication_translations pt
-  ON pt.publication_id = p.id AND pt.locale = $1
-WHERE p.collection_id = $2
-ORDER BY p.created_at DESC;
-```
-
-## JSON shape (mirrors app types)
-
-```json
-{
-  "id": "10000000-0000-0000-0000-000000000001",
-  "collectionId": "00000000-0000-0000-0000-000000000001",
-  "title": "Technical Analysis of the Financial Markets",
-  "coverImage": "https://example.com/images/publications/financial-marketing.jpg",
-  "status": "published",
-  "category": "Marketing",
-  "teaser": "Insights into impactful campaigns and digital tools.",
-  "description": "Discover the art and science of financial marketing in this comprehensive guide...",
-  "author": "Hirschi/Trepp/Zulliger",
-  "language": "de",
-  "releaseDate": "2024-10-08",
-  "isbnIssn": "978-3-16-148410-0",
-  "indexOffset": 0,
-  "documentPrintAllowed": false,
-  "previewPages": 30,
-  "orientation": "portrait",
-  "presentation": false
+```javascript
+function editRow(id) {
+  // Logic for editing a row, e.g., show a form to update the record.
+  console.log(`Edit record with ID: ${id}`);
 }
 ```
 
-## Notes
-- All dates are UTC; use timestamptz.
-- Keep i18n text out of the base table when it needs per-locale variants; use publication_translations.
-- Enforce updated_at via trigger if available.
-- Works well with MCP backends like Neon + Prisma. If you plan to connect a DB, you can Connect to Neon via the MCP popover and generate this schema.
+#### Example Delete Function:
+
+```javascript
+function deleteRow(id) {
+  // Logic for deleting a row, e.g., make an API call to delete the record.
+  console.log(`Delete record with ID: ${id}`);
+}
+```
+
+### 4. Language Support (Optional)
+
+If you want your table to support multiple languages (e.g., French, Spanish, German), you can use Builder.io’s I18N integration. Add translations for the table headings, buttons, and any dynamic content that is language-dependent.
+
+```javascript
+const translations = {
+  en: {
+    name: 'Name',
+    age: 'Age',
+    country: 'Country',
+    actions: 'Actions'
+  },
+  fr: {
+    name: 'Nom',
+    age: 'Âge',
+    country: 'Pays',
+    actions: 'Actions'
+  },
+  // Add other languages as needed
+};
+
+// Update table headings based on selected language
+const currentLanguage = 'fr';  // Example: dynamic based on user selection
+
+document.querySelector('th:nth-child(2)').textContent = translations[currentLanguage].name;
+document.querySelector('th:nth-child(3)').textContent = translations[currentLanguage].age;
+document.querySelector('th:nth-child(4)').textContent = translations[currentLanguage].country;
+document.querySelector('th:nth-child(5)').textContent = translations[currentLanguage].actions;
+```
+
+### 5. Styling
+
+To customize the table's appearance, you can use CSS or Builder.io’s design options. Here's an example of how you might style the table:
+
+```css
+#dynamic-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 20px 0;
+}
+
+#dynamic-table th, #dynamic-table td {
+  padding: 10px;
+  text-align: left;
+  border: 1px solid #ddd;
+}
+
+#dynamic-table th {
+  background-color: #f4f4f4;
+}
+
+button {
+  padding: 5px 10px;
+  margin: 2px;
+  cursor: pointer;
+}
+```
+
+## Conclusion
+
+This document outlines the basic steps for integrating a dynamic table structure into your Builder.io project. The table can be populated with data from an API and features editable and deletable rows. Additional customization options like language support and styling are also included to enhance the table’s functionality and appearance.

--- a/table.md
+++ b/table.md
@@ -1,5 +1,5 @@
-
 # Table Structure Integration
+
 ## Overview
 
 This document provides the structure and integration steps for embedding a static table structure into your Builder.io project. It guides you through creating a basic table that doesn't rely on dynamic data.
@@ -7,6 +7,7 @@ This document provides the structure and integration steps for embedding a stati
 ## Table Structure Example
 
 The table will consist of the following columns:
+
 - **ID**
 - **Name**
 - **Age**
@@ -15,11 +16,11 @@ The table will consist of the following columns:
 
 ### Example Static Table:
 
-| ID  | Name      | Age | Country | Actions  |
-|-----|-----------|-----|---------|----------|
-| 1   | John Doe  | 30  | USA     | Edit | Delete |
-| 2   | Jane Smith| 25  | Canada  | Edit | Delete |
-| 3   | Robert Brown | 45  | UK  | Edit | Delete |
+| ID  | Name         | Age | Country | Actions |
+| --- | ------------ | --- | ------- | ------- | ------ |
+| 1   | John Doe     | 30  | USA     | Edit    | Delete |
+| 2   | Jane Smith   | 25  | Canada  | Edit    | Delete |
+| 3   | Robert Brown | 45  | UK      | Edit    | Delete |
 
 ## Integration Steps
 
@@ -62,7 +63,8 @@ To customize the table's appearance, you can use CSS or Builder.io’s design op
   margin: 20px 0;
 }
 
-#static-table th, #static-table td {
+#static-table th,
+#static-table td {
   padding: 10px;
   text-align: left;
   border: 1px solid #ddd;

--- a/table.md
+++ b/table.md
@@ -1,0 +1,240 @@
+# Promag Data Tables
+
+This document defines a practical, production-ready relational schema for the app. It matches the current UI (collections, publications, i18n) and is suitable for Postgres (incl. Neon). Use or adapt as needed.
+
+## Entity overview
+
+- collections: Groups publications
+- publications: A publication belongs to one collection
+- publication_translations: Localized text fields per publication and locale
+- enums: publication_status_enum, orientation_enum
+
+```mermaid
+flowchart LR
+  C[collections] -->|1..N| P[publications]
+  P -->|1..N| PT[publication_translations]
+```
+
+## Tables
+
+### 1) collections
+
+| Column       | Type        | Constraints                          | Notes                              |
+|--------------|-------------|--------------------------------------|------------------------------------|
+| id           | uuid        | PK, default gen_random_uuid()        |                                     |
+| title        | text        | NOT NULL                             | Display name                        |
+| cover_image  | text        |                                      | Public URL or path                  |
+| created_at   | timestamptz | NOT NULL DEFAULT now()               |                                     |
+| updated_at   | timestamptz | NOT NULL DEFAULT now()               | Use trigger to keep updated         |
+
+Indexes: (title) for quick search.
+
+### 2) publications
+
+| Column                 | Type                  | Constraints                                    | Notes                                      |
+|------------------------|-----------------------|------------------------------------------------|--------------------------------------------|
+| id                     | uuid                  | PK, default gen_random_uuid()                  |                                            |
+| collection_id          | uuid                  | NOT NULL REFERENCES collections(id) ON DELETE CASCADE | Parent collection                  |
+| title                  | text                  | NOT NULL                                       | Canonical (fallback) title                 |
+| cover_image            | text                  |                                                | Public URL or path                          |
+| status                 | publication_status_enum | NOT NULL DEFAULT 'draft'                     | draft, published, pending                  |
+| category               | text                  |                                                | E.g. Marketing, Education                   |
+| edition                | text                  |                                                |                                            |
+| teaser                 | text                  |                                                | Short summary                              |
+| description            | text                  |                                                | Long description                           |
+| author                 | text                  |                                                | "Surname1/Surname2/..."                    |
+| editor                 | text                  |                                                |                                            |
+| language               | text                  | CHECK (char_length(language) IN (2,5))         | IETF/ISO code (e.g. 'en', 'de-DE')         |
+| release_date           | date                  |                                                |                                            |
+| isbn_issn              | text                  |                                                |                                            |
+| index_offset           | integer               | NOT NULL DEFAULT 0                             |                                            |
+| document_print_allowed | boolean               | NOT NULL DEFAULT false                         |                                            |
+| preview_pages          | integer               |                                                | Number of pages visible in preview         |
+| orientation            | orientation_enum      |                                                | portrait, landscape                        |
+| presentation           | boolean               | NOT NULL DEFAULT false                         |                                            |
+| created_at             | timestamptz           | NOT NULL DEFAULT now()                         |                                            |
+| updated_at             | timestamptz           | NOT NULL DEFAULT now()                         |                                            |
+
+Indexes:
+- (collection_id)
+- (status)
+- (title gin_trgm_ops) for fuzzy search (requires pg_trgm)
+
+### 3) publication_translations
+
+Localized copies of user-facing text for each locale.
+
+| Column        | Type        | Constraints                                         | Notes                              |
+|---------------|-------------|-----------------------------------------------------|------------------------------------|
+| id            | uuid        | PK, default gen_random_uuid()                       |                                    |
+| publication_id| uuid        | NOT NULL REFERENCES publications(id) ON DELETE CASCADE | Parent                         |
+| locale        | text        | NOT NULL                                            | e.g. 'en', 'de', 'es', 'fr'       |
+| title         | text        |                                                     | Localized title                    |
+| teaser        | text        |                                                     | Localized teaser                   |
+| description   | text        |                                                     | Localized description              |
+| created_at    | timestamptz | NOT NULL DEFAULT now()                              |                                    |
+| updated_at    | timestamptz | NOT NULL DEFAULT now()                              |                                    |
+
+Constraints:
+- UNIQUE (publication_id, locale)
+
+## SQL DDL
+
+```sql
+-- Enums
+CREATE TYPE publication_status_enum AS ENUM ('draft', 'published', 'pending');
+CREATE TYPE orientation_enum AS ENUM ('portrait', 'landscape');
+
+-- collections
+CREATE TABLE IF NOT EXISTS collections (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  title text NOT NULL,
+  cover_image text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_collections_title ON collections (title);
+
+-- publications
+CREATE TABLE IF NOT EXISTS publications (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  collection_id uuid NOT NULL REFERENCES collections(id) ON DELETE CASCADE,
+  title text NOT NULL,
+  cover_image text,
+  status publication_status_enum NOT NULL DEFAULT 'draft',
+  category text,
+  edition text,
+  teaser text,
+  description text,
+  author text,
+  editor text,
+  language text CHECK (char_length(language) IN (2,5)),
+  release_date date,
+  isbn_issn text,
+  index_offset integer NOT NULL DEFAULT 0,
+  document_print_allowed boolean NOT NULL DEFAULT false,
+  preview_pages integer,
+  orientation orientation_enum,
+  presentation boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_publications_collection_id ON publications (collection_id);
+CREATE INDEX IF NOT EXISTS idx_publications_status ON publications (status);
+-- Optional fuzzy search
+-- CREATE EXTENSION IF NOT EXISTS pg_trgm;
+-- CREATE INDEX IF NOT EXISTS idx_publications_title_trgm ON publications USING gin (title gin_trgm_ops);
+
+-- translations
+CREATE TABLE IF NOT EXISTS publication_translations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  publication_id uuid NOT NULL REFERENCES publications(id) ON DELETE CASCADE,
+  locale text NOT NULL,
+  title text,
+  teaser text,
+  description text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (publication_id, locale)
+);
+```
+
+## Example data (seed)
+
+```sql
+-- 1) Create a collection
+INSERT INTO collections (id, title, cover_image)
+VALUES (
+  '00000000-0000-0000-0000-000000000001',
+  'Publications',
+  'https://example.com/images/collections/publications.jpg'
+);
+
+-- 2) Create a publication (canonical fields in English as fallback)
+INSERT INTO publications (
+  id, collection_id, title, cover_image, status, category, teaser, description,
+  author, language, release_date, isbn_issn, preview_pages, orientation, presentation
+) VALUES (
+  '10000000-0000-0000-0000-000000000001',
+  '00000000-0000-0000-0000-000000000001',
+  'Technical Analysis of the Financial Markets',
+  'https://example.com/images/publications/financial-marketing.jpg',
+  'published',
+  'Marketing',
+  'Insights into impactful campaigns and digital tools.',
+  'Discover the art and science of financial marketing in this comprehensive guide tailored for professionals in the finance industry. Mastering Financial Marketing offers actionable insights into crafting impactful campaigns, leveraging digital tools, and staying compliant with industry regulations.',
+  'Hirschi/Trepp/Zulliger',
+  'de',
+  '2024-10-08',
+  '978-3-16-148410-0',
+  30,
+  'portrait',
+  false
+);
+
+-- 3) Localizations (German shown as primary, plus English fallback)
+INSERT INTO publication_translations (publication_id, locale, title, teaser, description)
+VALUES
+  ('10000000-0000-0000-0000-000000000001', 'de',
+   'Technische Analyse der Finanzmärkte',
+   'Einblicke in wirkungsvolle Kampagnen und digitale Tools.',
+   'Entdecken Sie die Kunst und Wissenschaft des Finanzmarketings in diesem umfassenden Leitfaden für Fachkräfte der Finanzbranche. Das Beherrschen des Finanzmarketings bietet umsetzbare Einblicke in die Erstellung wirkungsvoller Kampagnen, die Nutzung digitaler Tools und die Einhaltung von Branchenvorschriften.'),
+  ('10000000-0000-0000-0000-000000000001', 'en',
+   'Technical Analysis of the Financial Markets',
+   'Insights into impactful campaigns and digital tools.',
+   'Discover the art and science of financial marketing in this comprehensive guide tailored for professionals in the finance industry. Mastering Financial Marketing offers actionable insights into crafting impactful campaigns, leveraging digital tools, and staying compliant with industry regulations.');
+```
+
+## Example query: fetch by locale with fallback
+
+```sql
+-- :locale is the desired language code (e.g., 'de')
+SELECT
+  p.id,
+  p.collection_id,
+  COALESCE(pt.title, p.title)              AS title,
+  COALESCE(pt.teaser, p.teaser)            AS teaser,
+  COALESCE(pt.description, p.description)  AS description,
+  p.cover_image,
+  p.status,
+  p.category,
+  p.author,
+  p.language,
+  p.release_date,
+  p.preview_pages
+FROM publications p
+LEFT JOIN publication_translations pt
+  ON pt.publication_id = p.id AND pt.locale = $1
+WHERE p.collection_id = $2
+ORDER BY p.created_at DESC;
+```
+
+## JSON shape (mirrors app types)
+
+```json
+{
+  "id": "10000000-0000-0000-0000-000000000001",
+  "collectionId": "00000000-0000-0000-0000-000000000001",
+  "title": "Technical Analysis of the Financial Markets",
+  "coverImage": "https://example.com/images/publications/financial-marketing.jpg",
+  "status": "published",
+  "category": "Marketing",
+  "teaser": "Insights into impactful campaigns and digital tools.",
+  "description": "Discover the art and science of financial marketing in this comprehensive guide...",
+  "author": "Hirschi/Trepp/Zulliger",
+  "language": "de",
+  "releaseDate": "2024-10-08",
+  "isbnIssn": "978-3-16-148410-0",
+  "indexOffset": 0,
+  "documentPrintAllowed": false,
+  "previewPages": 30,
+  "orientation": "portrait",
+  "presentation": false
+}
+```
+
+## Notes
+- All dates are UTC; use timestamptz.
+- Keep i18n text out of the base table when it needs per-locale variants; use publication_translations.
+- Enforce updated_at via trigger if available.
+- Works well with MCP backends like Neon + Prisma. If you plan to connect a DB, you can Connect to Neon via the MCP popover and generate this schema.

--- a/table.md
+++ b/table.md
@@ -1,4 +1,4 @@
-# Table Structure Integration
+## Table Structure Integration
 
 ## Overview
 

--- a/table.md
+++ b/table.md
@@ -1,5 +1,5 @@
 
-# Static Table Structure Integration
+# Table Structure Integration
 ## Overview
 
 This document provides the structure and integration steps for embedding a static table structure into your Builder.io project. It guides you through creating a basic table that doesn't rely on dynamic data.

--- a/table.md
+++ b/table.md
@@ -1,8 +1,8 @@
-## Table Structure Integration
 
+# Static Table Structure Integration
 ## Overview
 
-This document provides the structure and integration steps for embedding a dynamic table structure into this project. It guides you through creating a table, integrating it, and leveraging Builder.io's content management features to control and display dynamic data.
+This document provides the structure and integration steps for embedding a static table structure into your Builder.io project. It guides you through creating a basic table that doesn't rely on dynamic data.
 
 ## Table Structure Example
 
@@ -13,7 +13,7 @@ The table will consist of the following columns:
 - **Country**
 - **Actions** (edit, delete)
 
-### Example Table:
+### Example Static Table:
 
 | ID  | Name      | Age | Country | Actions  |
 |-----|-----------|-----|---------|----------|
@@ -25,14 +25,14 @@ The table will consist of the following columns:
 
 ### 1. Create Table Structure in Builder.io
 
-To integrate a table into your Builder.io project, you first need to create a basic table structure:
+To integrate a static table into your Builder.io project, you first need to create a basic table structure:
 
 1. Go to the Builder.io dashboard and navigate to your project.
 2. In your page or template, add a custom **HTML Block** or use the **Custom Code** feature.
 3. Copy and paste the HTML code for the table as shown in the example above.
 
 ```html
-<table id="dynamic-table">
+<table id="static-table">
   <thead>
     <tr>
       <th>ID</th>
@@ -42,107 +42,50 @@ To integrate a table into your Builder.io project, you first need to create a ba
       <th>Actions</th>
     </tr>
   </thead>
-  <tbody id="table-body">
-    <!-- Dynamic Rows will be inserted here -->
+  <tbody>
+    <tr>
+      <td>1</td>
+      <td>John Doe</td>
+      <td>30</td>
+      <td>USA</td>
+      <td>Edit | Delete</td>
+    </tr>
+    <tr>
+      <td>2</td>
+      <td>Jane Smith</td>
+      <td>25</td>
+      <td>Canada</td>
+      <td>Edit | Delete</td>
+    </tr>
+    <tr>
+      <td>3</td>
+      <td>Robert Brown</td>
+      <td>45</td>
+      <td>UK</td>
+      <td>Edit | Delete</td>
+    </tr>
   </tbody>
 </table>
 ```
 
-### 2. Dynamic Data Integration
-
-To fetch data dynamically and display it in the table, use Builder.io's API or external data sources like a REST API. You can configure Builder.io to pull this data into the table structure.
-
-#### Example API integration:
-
-```javascript
-fetch('https://api.example.com/data')
-  .then(response => response.json())
-  .then(data => {
-    const tableBody = document.getElementById('table-body');
-    data.forEach(item => {
-      const row = document.createElement('tr');
-      row.innerHTML = `
-        <td>${item.id}</td>
-        <td>${item.name}</td>
-        <td>${item.age}</td>
-        <td>${item.country}</td>
-        <td><button onclick="editRow(${item.id})">Edit</button> <button onclick="deleteRow(${item.id})">Delete</button></td>
-      `;
-      tableBody.appendChild(row);
-    });
-  });
-```
-
-### 3. Edit and Delete Actions
-
-To manage the edit and delete actions for the table rows, you need to implement functions that handle these actions. These can be linked to your data API or a database.
-
-#### Example Edit Function:
-
-```javascript
-function editRow(id) {
-  // Logic for editing a row, e.g., show a form to update the record.
-  console.log(`Edit record with ID: ${id}`);
-}
-```
-
-#### Example Delete Function:
-
-```javascript
-function deleteRow(id) {
-  // Logic for deleting a row, e.g., make an API call to delete the record.
-  console.log(`Delete record with ID: ${id}`);
-}
-```
-
-### 4. Language Support (Optional)
-
-If you want your table to support multiple languages (e.g., French, Spanish, German), you can use Builder.io’s I18N integration. Add translations for the table headings, buttons, and any dynamic content that is language-dependent.
-
-```javascript
-const translations = {
-  en: {
-    name: 'Name',
-    age: 'Age',
-    country: 'Country',
-    actions: 'Actions'
-  },
-  fr: {
-    name: 'Nom',
-    age: 'Âge',
-    country: 'Pays',
-    actions: 'Actions'
-  },
-  // Add other languages as needed
-};
-
-// Update table headings based on selected language
-const currentLanguage = 'fr';  // Example: dynamic based on user selection
-
-document.querySelector('th:nth-child(2)').textContent = translations[currentLanguage].name;
-document.querySelector('th:nth-child(3)').textContent = translations[currentLanguage].age;
-document.querySelector('th:nth-child(4)').textContent = translations[currentLanguage].country;
-document.querySelector('th:nth-child(5)').textContent = translations[currentLanguage].actions;
-```
-
-### 5. Styling
+### 2. Styling the Static Table
 
 To customize the table's appearance, you can use CSS or Builder.io’s design options. Here's an example of how you might style the table:
 
 ```css
-#dynamic-table {
+#static-table {
   width: 100%;
   border-collapse: collapse;
   margin: 20px 0;
 }
 
-#dynamic-table th, #dynamic-table td {
+#static-table th, #static-table td {
   padding: 10px;
   text-align: left;
   border: 1px solid #ddd;
 }
 
-#dynamic-table th {
+#static-table th {
   background-color: #f4f4f4;
 }
 
@@ -155,4 +98,4 @@ button {
 
 ## Conclusion
 
-This document outlines the basic steps for integrating a dynamic table structure into your Builder.io project. The table can be populated with data from an API and features editable and deletable rows. Additional customization options like language support and styling are also included to enhance the table’s functionality and appearance.
+This document outlines the basic steps for integrating a static table structure into your Builder.io project. The table includes basic columns for displaying static data like ID, Name, Age, and Country. You can customize the appearance with CSS and manage table structure directly within Builder.io.

--- a/table.md
+++ b/table.md
@@ -23,46 +23,29 @@ The table will consist of the following columns:
 
 ## Integration Steps
 
-### 1. Create Table Structure in Builder.io
+### 1. Create Table Structure
 
-To integrate a static table into your Builder.io project, you first need to create a basic table structure:
+To integrate a static table into this project, you first need to create a basic table structure:
 
-1. Go to the Builder.io dashboard and navigate to your project.
-2. In your page or template, add a custom **HTML Block** or use the **Custom Code** feature.
-3. Copy and paste the HTML code for the table as shown in the example above.
+1. In this page or template, add a custom **HTML Block** or use the **Custom Code** feature.
+2. Copy and paste the HTML code for the table as shown in the example above.
 
 ```html
 <table id="static-table">
   <thead>
     <tr>
-      <th>ID</th>
-      <th>Name</th>
-      <th>Age</th>
-      <th>Country</th>
-      <th>Actions</th>
+      <th>content</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td>1</td>
-      <td>John Doe</td>
-      <td>30</td>
-      <td>USA</td>
-      <td>Edit | Delete</td>
+      <td><p>content</p></td>
     </tr>
     <tr>
-      <td>2</td>
-      <td>Jane Smith</td>
-      <td>25</td>
-      <td>Canada</td>
-      <td>Edit | Delete</td>
+      <td><p>content</p></td>
     </tr>
     <tr>
-      <td>3</td>
-      <td>Robert Brown</td>
-      <td>45</td>
-      <td>UK</td>
-      <td>Edit | Delete</td>
+      <td><p>content</p></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## Purpose

The user requested the creation of a Markdown file for table structure documentation to better understand the agent functionality, along with an example. This was part of a broader conversation about converting Figma designs to responsive code and improving project documentation.

## Code changes

- **Added PublicationViewModal component**: Created a new modal component for viewing publication details with actions (edit, share, delete, clone, settings) and status management
- **Enhanced PublicationListView**: Integrated the new modal, added click handlers for publication cards, and extended the Publication interface with additional fields (author, editor, language, etc.)
- **Updated translations**: Added new translation keys for the publication view modal in English, German, Spanish, and French locales
- **Created table.md documentation**: Added comprehensive documentation for table structure integration with examples, HTML structure, CSS styling, and implementation steps
- **Updated AGENTS.md**: Added reference to the new table structure documentation

The changes include both UI enhancements for better publication management and documentation improvements for developer guidance.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 17`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1ab459c3d64046cf9f79e6df707dd801/spark-works)

👀 [Preview Link](https://1ab459c3d64046cf9f79e6df707dd801-spark-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1ab459c3d64046cf9f79e6df707dd801</projectId>-->
<!--<branchName>spark-works</branchName>-->